### PR TITLE
Naively scale up gLTFs for now, add orbit controls

### DIFF
--- a/src/components/ModelPreviewer.svelte
+++ b/src/components/ModelPreviewer.svelte
@@ -1,20 +1,35 @@
 <script lang="ts">
 	import { T } from '@threlte/core'
-	import { GLTF } from '@threlte/extras'
+	import { GLTF, OrbitControls, interactivity } from '@threlte/extras'
+	interactivity()
 	export let dataUrl: string
+
+	let shouldAutoRotate = true
+	const AUTO_ROTATE_PAUSE = 5000
+
+	let autorotateTimeout: ReturnType<typeof setTimeout> | undefined
+	const disableAutoRotate = () => {
+		shouldAutoRotate = false
+		clearTimeout(autorotateTimeout)
+	}
+	const reenableAutoRotate = () => {
+		autorotateTimeout = setTimeout(function () {
+			shouldAutoRotate = true
+		}, AUTO_ROTATE_PAUSE)
+	}
 </script>
 
-<T.PerspectiveCamera
-	makeDefault
-	on:create={({ ref }) => {
-		ref.lookAt(0, 1, 0)
-	}}
-/>
+<T.PerspectiveCamera makeDefault fov={50} position={[20, 20, 20]}>
+	<OrbitControls
+		enableDamping
+		autoRotate={shouldAutoRotate}
+		on:start={disableAutoRotate}
+		on:end={reenableAutoRotate}
+	/>
+</T.PerspectiveCamera>
 
-<GLTF
-	url={dataUrl}
-	position={[0, 1, 0]}
-	on:load={(payload) => {
-		console.log('loaded', payload)
-	}}
-/>
+<T.AmbientLight color="white" />
+<T.DirectionalLight color="white" />
+<T.DirectionalLight color="white" position={[5, 0, -5]} />
+
+<GLTF url={dataUrl} position={[0, 0, 0]} scale={300} />


### PR DESCRIPTION
Now you can at least see and kinda interact with your gLTF model previews:

<img width="1307" alt="Screenshot 2023-10-19 at 12 37 16 PM" src="https://github.com/KittyCAD/text-to-cad-ui/assets/23481541/a321ee57-399f-470d-a991-f80d96c30e81">

<img width="1254" alt="Screenshot 2023-10-19 at 12 37 28 PM" src="https://github.com/KittyCAD/text-to-cad-ui/assets/23481541/519b217b-7015-4afe-9494-c059ce1fff91">

I still have to figure out:
1. editing/adding to materials in a loaded gLTF
2. being smarter about scaling in case someone generates a huge thing and it's naively scaled up even bigger