### PR TITLE
Turn variables into stores to keep them while navigating

### DIFF
--- a/src/components/GenerationList.svelte
+++ b/src/components/GenerationList.svelte
@@ -16,7 +16,7 @@
 	let isFetching = false
 
 	async function fetchData() {
-		if ($nextPageToken === null || isFetching) return
+		if ($nextPageToken === null) return
 		isFetching = true
 
 		const response = await fetch(endpoints.localList, {

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -2,4 +2,4 @@ import type { Models } from '@kittycad/lib'
 import { writable } from 'svelte/store'
 
 export const generations = writable<Models['TextToCad_type'][]>([])
-export const nextPageToken = writable<string | null>(null)
+export const nextPageToken = writable<string | null | undefined>(undefined)


### PR DESCRIPTION
Resolves #26 by turning the plain reactive variables in `GenerationList` into writable stores, so that we don't have to re-fetch all of them every time the user goes back to the home page unless they do a full page refresh for some reason. @jessfraz @Irev-Dev this is the kind of thing I absolutely love Svelte for 🧡