### PR TITLE
Show failed generations instead of filtering them

### DIFF
--- a/src/components/GenerationList.svelte
+++ b/src/components/GenerationList.svelte
@@ -11,7 +11,6 @@
 
 	export let additionalGenerations: Models['TextToCad_type'][] = []
 
-	const filterFailures = (item: Models['TextToCad_type']) => item.status !== 'failed'
 	let PAGE_SIZE = 2
 	let isFetching = false
 
@@ -40,6 +39,8 @@
 				newGenerations.find((item) => item.id === id)
 			) as Models['TextToCad_type'][]
 		})
+
+		console.log($generations)
 	}
 
 	onMount(() => {
@@ -58,12 +59,12 @@
 		<ul class="m-0 p-0">
 			{#each additionalGenerations as item}
 				<li class="first-of-type:mt-0 my-12">
-					<GenerationListItem data={item} />
+					<GenerationListItem data={item} on:retryprompt />
 				</li>
 			{/each}
-			{#each $generations.filter(filterFailures) as item}
+			{#each $generations as item}
 				<li class="first-of-type:mt-0 my-12">
-					<GenerationListItem data={item} />
+					<GenerationListItem data={item} on:retryprompt />
 				</li>
 			{/each}
 		</ul>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,3 @@
+export type GenerationEvents = {
+	retryprompt: string
+}


### PR DESCRIPTION
Based on [this design from Figma](https://www.figma.com/file/T0l4VyA7hfI3HwY7yv2Ruk/Text-to-CAD-UI?type=design&node-id=16-80&mode=design&t=KuWgRnNaOmePLc6d-11), show generation list items if they encountered a failure and couldn't complete. Also adds a Retry prompt button that fills in the form field with the same prompt if the user wants to try again.