### PR TITLE
Remove all non-alphanumeric chars in `toKebabCase`

### DIFF
--- a/src/lib/toKebabCase.ts
+++ b/src/lib/toKebabCase.ts
@@ -1,6 +1,6 @@
 export function toKebabCase(str: string) {
 	return str
-		.replace(/([a-z])([A-Z])/g, '$1-$2')
-		.replace(/\s+/g, '-')
 		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, '-')
+		.replace(/\s+/g, '-')
 }


### PR DESCRIPTION
And also perform `toLowerCase` first instead of last to make the rest of the Regex simpler.

Now this prompt:
```
design a brick: 8 in. long, 4 in. deep, 2 in. tall—chamfered edged
```

begets this file name:
```
design-a-brick-8-in-long-4-in-deep-2-in-tall-chamfered-edged.gltf
```