### PR TITLE
Add optional chaining because name can be undefined

### DIFF
--- a/src/components/AccountMenu.svelte
+++ b/src/components/AccountMenu.svelte
@@ -38,8 +38,10 @@
 		{#if shouldDisplayInitial}
 			<span
 				class="w-5 h-5 font-bold text-xl leading-[1] pt-0.5 text-center text-chalkboard-10 dark:text-chalkboard-120"
-				data-testid="initial">{user.name?.[0] || user.first_name?.[0] || user.email?.[0]}</span
+				data-testid="initial"
 			>
+				{user.name?.[0] || user.first_name?.[0] || user.email?.[0]}
+			</span>
 		{:else if !shouldDisplayImage}
 			<Person
 				data-testid="person-icon"

--- a/src/components/AccountMenu.svelte
+++ b/src/components/AccountMenu.svelte
@@ -38,7 +38,7 @@
 		{#if shouldDisplayInitial}
 			<span
 				class="w-5 h-5 font-bold text-xl leading-[1] pt-0.5 text-center text-chalkboard-10 dark:text-chalkboard-120"
-				data-testid="initial">{user.name[0] || user.first_name[0] || user.email[0]}</span
+				data-testid="initial">{user.name?.[0] || user.first_name?.[0] || user.email?.[0]}</span
 			>
 		{:else if !shouldDisplayImage}
 			<Person


### PR DESCRIPTION
The type of `Models['User_type']['name']` is actually `string | undefined` but comes back as `string` from `@kittycad/lib`, so users without names were receiving `500` errors when trying to load the dashboard.