### PR TITLE
Add more unit tests and fix sign out

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -4,6 +4,8 @@ import { users, Client } from '@kittycad/lib'
 import { SIGN_OUT_PARAM } from '$lib/paths'
 const unProtectedRoutes = ['/']
 
+const domain = import.meta.env.DEV ? 'localhost' : import.meta.env.VITE_SITE_BASE_URL
+
 export const handle = async ({ event, resolve }) => {
 	const token = event.cookies.get(AUTH_COOKIE_NAME)
 	if (!token && !unProtectedRoutes.includes(event.url.pathname)) {
@@ -35,7 +37,7 @@ export const handle = async ({ event, resolve }) => {
 	const query = event.url.searchParams.get(SIGN_OUT_PARAM)
 
 	if (Boolean(query) == true) {
-		event.cookies.delete(AUTH_COOKIE_NAME, { domain: event.url.hostname, path: '/' })
+		event.cookies.delete(AUTH_COOKIE_NAME, { domain, path: '/' })
 		event.url.searchParams.delete(SIGN_OUT_PARAM)
 		throw redirect(303, '/')
 	}

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -1,13 +1,9 @@
 import type { Models } from '@kittycad/lib'
 import { derived, writable } from 'svelte/store'
 import groupBy from 'object.groupby'
-import {
-	PERSIST_KEY_GENERATIONS,
-	PERSIST_KEY_UNREAD,
-	PERSIST_KEY_VERSION,
-	TIME_BUCKETS
-} from './consts'
+import { PERSIST_KEY_GENERATIONS, PERSIST_KEY_UNREAD, PERSIST_KEY_VERSION } from './consts'
 import { browser } from '$app/environment'
+import { bucketByTime } from './time'
 
 // Clear local storage if the version has changed
 // This allows us to clear users' local storage if we need to
@@ -56,13 +52,7 @@ combinedGenerations.subscribe((value) => {
 })
 
 export const generations = derived([combinedGenerations], ([$combinedGenerations]) => {
-	return groupBy($combinedGenerations, ({ created_at }) => {
-		const now = new Date()
-		const createdAtDate = new Date(created_at)
-		const bucket = TIME_BUCKETS.find(({ test }) => test(createdAtDate, now))
-
-		return bucket?.name ?? createdAtDate.getFullYear().toString()
-	})
+	return groupBy($combinedGenerations, ({ created_at }) => bucketByTime(created_at))
 })
 
 export const nextPageToken = writable<string | null | undefined>(undefined)

--- a/src/lib/time.test.ts
+++ b/src/lib/time.test.ts
@@ -1,9 +1,11 @@
+import groupBy from 'object.groupby'
 import {
 	msSinceStartOfDay,
 	msSinceStartOfMonth,
 	msSinceAWeekAgo,
 	msSinceStartOfYear,
-	sortTimeBuckets
+	sortTimeBuckets,
+	bucketByTime
 } from './time'
 
 describe('time interval tests', () => {
@@ -44,5 +46,30 @@ describe('time bucketing tests', () => {
 			['2023', []],
 			['2021', []]
 		])
+	})
+
+	it('puts items in the right buckets', () => {
+		const now = new Date('2024-04-27T17:00:25.950')
+		const items = [
+			{ created_at: '2024-02-21T17:00:25.950' }, // This Year
+			{ created_at: '2024-04-27T09:00:25.950' }, // Today
+			{ created_at: '2024-04-21T17:00:25.950' }, // Past 7 Days
+			{ created_at: '2024-04-24T17:00:25.950' }, // Past 7 Days
+			{ created_at: '2022-03-21T17:00:25.950' }, // 2022
+			{ created_at: '2024-04-10T09:00:25.950' } // This Month
+		]
+		const bucketed = groupBy(items, ({ created_at }) => bucketByTime(created_at, now))
+
+		// TODO
+		expect(bucketed).toEqual({
+			Today: [{ created_at: '2024-04-27T09:00:25.950' }],
+			'Past 7 Days': [
+				{ created_at: '2024-04-21T17:00:25.950' },
+				{ created_at: '2024-04-24T17:00:25.950' }
+			],
+			'This Month': [{ created_at: '2024-04-10T09:00:25.950' }],
+			'This Year': [{ created_at: '2024-02-21T17:00:25.950' }],
+			'2022': [{ created_at: '2022-03-21T17:00:25.950' }]
+		})
 	})
 })

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -21,6 +21,13 @@ export function msSinceStartOfYear(date: Date) {
 	return date.getTime() - startOfYear.getTime()
 }
 
+export function bucketByTime(time: string, now = new Date()) {
+	const createdAtDate = new Date(time)
+	const bucket = TIME_BUCKETS.find(({ test }) => test(createdAtDate, now))
+
+	return bucket?.name ?? createdAtDate.getFullYear().toString()
+}
+
 export function sortTimeBuckets([a]: [string, unknown], [b]: [string, unknown]) {
 	const foundIndexA = TIME_BUCKETS.findIndex(({ name }) => name === a)
 	const foundIndexB = TIME_BUCKETS.findIndex(({ name }) => name === b)


### PR DESCRIPTION
Adds a unit test for the time bucketing of past prompts and removes the clever thing I tried to do to make sign out agnostic of Vercel preview, localhost or production