### PR TITLE
Add error card when generated model is empty

### DIFF
--- a/src/components/ModelViewer.svelte
+++ b/src/components/ModelViewer.svelte
@@ -35,7 +35,6 @@
 	let maxDistance = 0
 
 	$: if (dataUrl && $loadedModel) {
-		console.log($loadedModel)
 		// If the model is empty, we need to tell the parent component
 		// to show the empty scene error card
 		if (Object.values($loadedModel.nodes).length === 0) {

--- a/src/components/ModelViewer.svelte
+++ b/src/components/ModelViewer.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { T, useThrelte } from '@threlte/core'
 	import { GLTF, OrbitControls, interactivity, useGltf } from '@threlte/extras'
+	import { createEventDispatcher } from 'svelte'
 	import { Box3, Color, Vector3, Scene, Mesh } from 'three'
 
 	export let dataUrl: string
@@ -9,12 +10,14 @@
 	let readyToRender = false
 
 	const { size: threlteSize } = useThrelte()
+	const dispatch = createEventDispatcher()
 
 	interactivity()
 
 	let shouldAutoRotate = true
 	const AUTO_ROTATE_PAUSE = 5000
 
+	// This allows autorotate to be paused when the user is interacting with the model
 	let autorotateTimeout: ReturnType<typeof setTimeout> | undefined
 	const disableAutoRotate = () => {
 		if (!pausable) return
@@ -32,22 +35,33 @@
 	let maxDistance = 0
 
 	$: if (dataUrl && $loadedModel) {
-		;($loadedModel.scene as Scene).traverse((child) => {
-			if ('isMesh' in child && child.isMesh) {
-				const material = (child as Mesh).material
-				if (material instanceof Array && 'color' in material[0]) {
-					material[0].color = new Color(0x29ffa4)
-				} else if ('color' in material) {
-					material.color = new Color(0x29ffa4)
+		console.log($loadedModel)
+		// If the model is empty, we need to tell the parent component
+		// to show the empty scene error card
+		if (Object.values($loadedModel.nodes).length === 0) {
+			dispatch('emptyscene')
+		} else {
+			// Otherwise we'll traverse each mesh and set the color to green
+			;($loadedModel.scene as Scene).traverse((child) => {
+				if ('isMesh' in child && child.isMesh) {
+					const material = (child as Mesh).material
+					if (material instanceof Array && 'color' in material[0]) {
+						material[0].color = new Color(0x29ffa4)
+					} else if ('color' in material) {
+						material.color = new Color(0x29ffa4)
+					}
 				}
-			}
-		})
-		const size = new Vector3()
-		const boundingBox = new Box3()
-		boundingBox.setFromObject($loadedModel.scene)
-		boundingBox.getSize(size)
-		maxDistance = Math.max(size.x, size.y, size.z)
-		readyToRender = true
+			})
+
+			// Then we'll calculate the max distance of the bounding box
+			// and set that as the camera's position
+			const size = new Vector3()
+			const boundingBox = new Box3()
+			boundingBox.setFromObject($loadedModel.scene)
+			boundingBox.getSize(size)
+			maxDistance = Math.max(size.x, size.y, size.z)
+			readyToRender = true
+		}
 	}
 </script>
 


### PR DESCRIPTION
Presents the user with an error state if the successfully-generated model from a prompt turns out to be empty, as having an empty scene with successful UI was confusing and made it hard to tell if it was an issue with the camera or something else.

## Demo

https://github.com/KittyCAD/text-to-cad-ui/assets/23481541/68956c42-092b-4c6c-a175-ed592402debb