### PR TITLE
Make meta img URLs aboslute

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -22,7 +22,7 @@
 			name="twitter:description"
 			content="An interface for generating CAD files through text prompts."
 		/>
-		<meta name="twitter:image" content="/zoo-text-to-cad-social.jpg" />
+		<meta name="twitter:image" content="%sveltekit.assets%/zoo-text-to-cad-social.jpg" />
 		<meta
 			name="twitter:image:alt"
 			content="An interface for generating CAD files through text prompts."
@@ -39,7 +39,7 @@
 			property="og:description"
 			content="An interface for generating CAD files through text prompts."
 		/>
-		<meta property="og:image" content="/zoo-text-to-cad-social.jpg" />
+		<meta property="og:image" content="%sveltekit.assets%/zoo-text-to-cad-social.jpg" />
 		<meta
 			property="og:image:secure_url"
 			content="https://text-to-cad.zoo.dev/zoo-text-to-cad-social.jpg"

--- a/src/app.html
+++ b/src/app.html
@@ -22,7 +22,7 @@
 			name="twitter:description"
 			content="An interface for generating CAD files through text prompts."
 		/>
-		<meta name="twitter:image" content="%sveltekit.assets%/zoo-text-to-cad-social.jpg" />
+		<meta name="twitter:image" content="https://text-to-cad.zoo.dev/zoo-text-to-cad-social.jpg" />
 		<meta
 			name="twitter:image:alt"
 			content="An interface for generating CAD files through text prompts."
@@ -39,7 +39,7 @@
 			property="og:description"
 			content="An interface for generating CAD files through text prompts."
 		/>
-		<meta property="og:image" content="%sveltekit.assets%/zoo-text-to-cad-social.jpg" />
+		<meta property="og:image" content="https://text-to-cad.zoo.dev/zoo-text-to-cad-social.jpg" />
 		<meta
 			property="og:image:secure_url"
 			content="https://text-to-cad.zoo.dev/zoo-text-to-cad-social.jpg"


### PR DESCRIPTION
Metatags.io thinks relative URLs are fine but Twitter doesn't seem to any longer since some update in recent weeks. So I think using the SvelteKit magic string `%sveltekit.assets%` should put an absolute URL in there, since it's what we use successfully to get the favicons to work.