### PR TITLE
Add theme-based edges to models

### DIFF
--- a/src/components/ModelViewer.svelte
+++ b/src/components/ModelViewer.svelte
@@ -1,8 +1,18 @@
 <script lang="ts">
+	import { getTheme } from '$lib/getTheme'
 	import { T, useThrelte } from '@threlte/core'
 	import { GLTF, OrbitControls, interactivity, useGltf } from '@threlte/extras'
 	import { createEventDispatcher } from 'svelte'
-	import { Box3, Color, Vector3, Scene, Mesh } from 'three'
+	import {
+		Box3,
+		Color,
+		Vector3,
+		Scene,
+		Mesh,
+		EdgesGeometry,
+		LineSegments,
+		LineBasicMaterial
+	} from 'three'
 
 	export let dataUrl: string
 	export let pausable = true
@@ -50,6 +60,13 @@
 					} else if ('color' in material) {
 						material.color = new Color(0x29ffa4)
 					}
+
+					const edges = new EdgesGeometry((child as Mesh).geometry, 30)
+					const lines = new LineSegments(
+						edges,
+						new LineBasicMaterial({ color: getTheme() === 'light' ? 0xffffff : 0x1f2020 })
+					)
+					$loadedModel.scene.add(lines)
 				}
 			})
 

--- a/src/lib/getTheme.ts
+++ b/src/lib/getTheme.ts
@@ -1,0 +1,8 @@
+import { browser } from '$app/environment'
+
+export function getTheme() {
+	if (browser) {
+		return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+	}
+	return 'light'
+}


### PR DESCRIPTION
Add's edges to each generated model on load per @Irev-Dev and @jgomez720's feedback, that are colored to match the user's `prefers-color-scheme` settings, dark edges in dark mode and light edges in light.