### PR TITLE
Make viewport height account for address bar

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -14,7 +14,8 @@
 		<link rel="icon" type="image/png" sizes="32x32" href="%sveltekit.assets%/favicon-32x32.png" />
 		<link rel="icon" type="image/png" sizes="16x16" href="%sveltekit.assets%/favicon-16x16.png" />
 		<link rel="manifest" href="%sveltekit.assets%/site.webmanifest" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<!-- minimal-ui is an iOS-specific tag that makes the bottom address bar hidden by default -->
+		<meta name="viewport" content="width=device-width, initial-scale=1; minimal-ui" />
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="Zoo Text-to-CAD UI" />
 		<meta name="twitter:site" content="@zoodotdev" />

--- a/src/routes/(sidebarLayout)/+layout.svelte
+++ b/src/routes/(sidebarLayout)/+layout.svelte
@@ -5,7 +5,7 @@
 	export let data: LayoutData
 </script>
 
-<div class="h-screen overflow-hidden flex flex-col">
+<div class="h-screen overflow-hidden flex flex-col" style="height: 100dvh;">
 	<div class="pane-layout">
 		<Sidebar user={data ? data.user : undefined} className="md:w-80" />
 		<main>
@@ -23,6 +23,7 @@
 
 	.pane-layout {
 		@apply h-screen overflow-hidden flex flex-col md:flex-row;
+		height: 100dvh;
 	}
 
 	main {

--- a/src/routes/(sidebarLayout)/dashboard/+page.svelte
+++ b/src/routes/(sidebarLayout)/dashboard/+page.svelte
@@ -10,7 +10,7 @@
 	let input = null as HTMLTextAreaElement | null
 </script>
 
-<section class="mx-4 lg:mx-auto min-h-screen flex flex-col justify-end">
+<section class="mx-4 lg:mx-auto min-h-screen flex flex-col justify-end" style="height: 100dvh">
 	<div class="max-w-2xl mx-auto mt-12 lg:mt-16">
 		<h1 class="text-4xl md:text-5xl mb-2">
 			Text-to-<span class="text-green">CAD</span>

--- a/src/routes/(sidebarLayout)/view/[modelId]/+page.svelte
+++ b/src/routes/(sidebarLayout)/view/[modelId]/+page.svelte
@@ -30,7 +30,7 @@
 	$: gltfUrl = `data:model/gltf+json;base64,${data.outputs ? data.outputs['source.gltf'] : ''}`
 </script>
 
-<section class="min-h-screen flex flex-col">
+<section class="min-h-screen flex flex-col" style="min-height: 100dvh">
 	{#if $navigating}
 		<div class="flex-1 flex flex-col justify-center items-center">
 			<p class="link-text mb-4">Loading your model</p>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -13,7 +13,7 @@
 	]
 </script>
 
-<main class="mx-2 md:mx-5 lg:mx-auto min-h-screen flex items-center">
+<main class="mx-2 md:mx-5 lg:mx-auto min-h-screen flex items-center" style="min-height: 100dvh">
 	<section class="mx-auto max-w-5xl flex-1">
 		<div class="grid grid-cols-1 md:grid-cols-3 gap-0 items-stretch min-h-[33vh]">
 			<h1 class="md:col-span-2 text-5xl md:text-7xl py-6 md:py-12 self-center px-2 md:px-4">


### PR DESCRIPTION
It's annoying to try and reach the footer on iOS, because the min-height of the page is set to 100vh which in the case of the view page is just on the cusp where it's not big enough to scroll past the address bar. Thanks to the new `dvh` unit we can make the height of the viewport more accurate on those kinds of devices.