### PR TITLE
Try to properly set domain when deleting cookie for signout

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -15,7 +15,7 @@
 		<link rel="icon" type="image/png" sizes="16x16" href="%sveltekit.assets%/favicon-16x16.png" />
 		<link rel="manifest" href="%sveltekit.assets%/site.webmanifest" />
 		<!-- minimal-ui is an iOS-specific tag that makes the bottom address bar hidden by default -->
-		<meta name="viewport" content="width=device-width, initial-scale=1; minimal-ui" />
+		<meta name="viewport" content="width=device-width, initial-scale=1, minimal-ui" />
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="Zoo Text-to-CAD UI" />
 		<meta name="twitter:site" content="@zoodotdev" />

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -6,7 +6,7 @@ import { PLAYWRIGHT_MOCKING_HEADER } from '$lib/consts'
 import { hooksUserMocks, isUserMock } from '$lib/mocks'
 const unProtectedRoutes = ['/']
 
-const domain = import.meta.env.DEV ? 'localhost' : import.meta.env.VITE_SITE_BASE_URL
+const domain = import.meta.env.DEV ? 'localhost' : '.zoo.dev'
 
 export const handle = async ({ event, resolve }) => {
 	const mock = event.request.headers.get(PLAYWRIGHT_MOCKING_HEADER)


### PR DESCRIPTION
I had been setting the `domain` to be `https://zoo.dev` from an environment variable, but I think the cookie actually has a domain set to `.zoo.dev`