### PR TITLE
Simplify dev setup

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,2 @@
+VITE_API_BASE_URL=https://api.dev.zoo.dev
+VITE_SITE_BASE_URL=https://dev.zoo.dev

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,1 @@
-VITE_API_BASE_URL=https://api.dev.zoo.dev
-VITE_SITE_BASE_URL=https://dev.zoo.dev
-PLAYWRIGHT_SESSION_COOKIE="your-token-from-dev.zoo.dev"
-VITE_TOKEN="your-token-from-dev.zoo.dev"
+VITE_ZOO_DEV_TOKEN="your-token-from-dev.zoo.dev" # A dev API token from dev.zoo.dev

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ This repository is an open-source example of how to quickly get up and running w
 
 1. Remove the `.example` from `/.env.example`, leaving it `.env` (Git will ignore this and prevent you from accidentally publishing your dev API token)
 2. Set the `VITE_ZOO_DEV_TOKEN` environment variable in with a **dev** API token from: https://dev.zoo.dev in `/.env`
-3. Set the `PLAYWRIGHT_TESTING_TOKEN` environment variable with a **prod** API token from: https://zoo.dev in `/.env`
-4. Run the dev server with `yarn dev -- --open`
+3. Run the dev server with `yarn dev --open`
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,10 @@ This repository is an open-source example of how to quickly get up and running w
 ## Developing
 
 1. Generate a dev API token from https://dev.zoo.dev
-2. Set the `VITE_ZOO_DEV_TOKEN` environment variable in `./.env.example` to the generated dev API token
-3. Remove the `.example` from `/.env.example`, leaving it `.env` (Git will ignore this and prevent you from accidentally publishing your dev API token)
-4. Install [yarn](https://yarnpkg.com/getting-started/install)
-5. Install dependencies with `yarn global add vite` and `yarn install`
-6. Run the dev server with `yarn dev --open`
+2. Set the `VITE_ZOO_DEV_TOKEN` environment variable to the generated dev API token in a new file `./.env` in the root of the repo. See `./.env.example` for an example file.
+3. Install [yarn](https://yarnpkg.com/getting-started/install)
+4. Install dependencies with `yarn global add vite` and `yarn install`
+5. Run the dev server with `yarn dev --open`
 
 The full collection of scripts are listed in package.json.
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ This repository is an open-source example of how to quickly get up and running w
 
 ## Developing
 
-1. Get a dev api token from: https://dev.zoo.dev
-2. Set a `VITE_TOKEN` environment variable in `./.env.development`
-3. Run the dev server with `yarn dev -- --open`
+1. Remove the `.example` from `/.env.example`, leaving it `.env` (Git will ignore this and prevent you from accidentally publishing your dev API token)
+2. Set the `VITE_ZOO_DEV_TOKEN` environment variable in with a **dev** API token from: https://dev.zoo.dev in `/.env`
+3. Set the `PLAYWRIGHT_TESTING_TOKEN` environment variable with a **prod** API token from: https://zoo.dev in `/.env`
+4. Run the dev server with `yarn dev -- --open`
 
 ## Building
 
@@ -20,18 +21,11 @@ You can preview the production build with `yarn preview`.
 
 ## Before submitting a PR
 
-Please run the following commands to ensure that your code is as ready for review as it can be:
-
-```bash
-yarn fmt --fix && yarn test
-```
+Please run the `yarn prep` to lint, format, type-check and test your code to ensure it's as ready for code review as possible.
 
 ### Running Playwright E2E tests locally
 
-In order to run our Playwright testing suite locally, please set the `PLAYWRIGHT_SESSION_COOKIE` variable within `.env.development` to a token from a logged in local development session. You can retrieve it by:
+If you've set a `VITE_ZOO_DEV_TOKEN` in `/.env` as described above, you should be able to run the `yarn test` command successfully, which runs `yarn test:integration` and `yarn test:unit` in series.
 
-1. logging in to the project locally using the method outlined above
-2. opening the Application tab in your browser developer tools
-3. copying out the value of the cookie titled `__Secure-next-auth.session-token` with the domain of `localhost`
-
-Now you should be able to run the `yarn test:integration` and `yarn test` commands successfully.
+- We use [Playwright](https://playwright.dev) for end-to-end testing. Try running `yarn test:integration --ui` for a handy visualizer of your tests as they run!
+- We use [Vitest](https://vitest.dev) for unit and component testing.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 		"dev": "vite dev",
 		"build": "vite build",
 		"preview": "vite preview",
+		"prep": "yarn fmt --fix && yarn check && yarn lint && yarn test",
 		"test": "npm run test:integration && npm run test:unit run",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -14,7 +14,7 @@ const config: PlaywrightTestConfig = {
 			cookies: [
 				{
 					name: AUTH_COOKIE_NAME,
-					value: process.env.PLAYWRIGHT_SESSION_COOKIE ?? '',
+					value: process.env.VITE_ZOO_DEV_TOKEN ?? '',
 					domain: 'localhost',
 					path: '/',
 					expires: expiration.getTime() / 1000,

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -11,7 +11,7 @@ export const handle = async ({ event, resolve }) => {
 	const mock = event.request.headers.get(PLAYWRIGHT_MOCKING_HEADER)
 	const token = import.meta.env.PROD
 		? event.cookies.get(AUTH_COOKIE_NAME)
-		: import.meta.env.VITE_TOKEN
+		: import.meta.env.VITE_ZOO_DEV_TOKEN
 
 	if (!token && !unProtectedRoutes.includes(event.url.pathname)) {
 		throw redirect(303, '/')
@@ -32,7 +32,7 @@ export const handle = async ({ event, resolve }) => {
 			throw error(500, e)
 		})
 
-	if (!currentUser) {
+	if (!currentUser || 'message' in currentUser) {
 		event.locals.user = undefined
 		if (!unProtectedRoutes.includes(event.url.pathname)) throw redirect(303, '/')
 	} else {

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -5,7 +5,7 @@ export const load = async ({ locals, cookies }) => {
 	const token =
 		import.meta.env.MODE === 'production'
 			? cookies.get(AUTH_COOKIE_NAME)
-			: import.meta.env.VITE_TOKEN
+			: import.meta.env.VITE_ZOO_DEV_TOKEN
 
 	return {
 		user: !locals.user || 'error_code' in locals.user ? undefined : locals.user,

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,10 +1,30 @@
 import { AUTH_COOKIE_NAME } from '$lib/cookies.js'
-import { redirect } from '@sveltejs/kit'
+import { error, redirect } from '@sveltejs/kit'
+import type { Models } from '@kittycad/lib'
 
-export const load = async ({ cookies, url }) => {
-	const token = import.meta.env.PROD ? cookies.get(AUTH_COOKIE_NAME) : import.meta.env.VITE_TOKEN
+export const load = async ({ cookies, url, fetch }) => {
+	const token = import.meta.env.PROD
+		? cookies.get(AUTH_COOKIE_NAME)
+		: import.meta.env.VITE_ZOO_DEV_TOKEN
 
-	if (token) {
+	const currentUser = await fetch(import.meta.env.VITE_API_BASE_URL + '/user', {
+		method: 'GET',
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${token}`
+		}
+	})
+		.then(async (res) => (await res.json()) as Models['User_type'] | Models['Error_type'])
+		.catch((e) => {
+			throw error(500, e)
+		})
+
+	// Redirect to the dashboard if the user is already logged in
+	if (currentUser && 'email' in currentUser) {
 		throw redirect(302, '/dashboard' + (url.search || ''))
+	} else if (import.meta.env.DEV) {
+		console.warn(
+			'You might be using an invalid or expired token for your VITE_ZOO_DEV_TOKEN environment variable. Please check your .env file.'
+		)
 	}
 }

--- a/src/routes/api/convert/[output_format]/+server.ts
+++ b/src/routes/api/convert/[output_format]/+server.ts
@@ -9,7 +9,9 @@ export type ConvertResponse = Models['FileConversion_type'] & {
 }
 
 export const POST: RequestHandler = async ({ cookies, fetch, request, params }) => {
-	const token = import.meta.env.PROD ? cookies.get(AUTH_COOKIE_NAME) : import.meta.env.VITE_TOKEN
+	const token = import.meta.env.PROD
+		? cookies.get(AUTH_COOKIE_NAME)
+		: import.meta.env.VITE_ZOO_DEV_TOKEN
 	if (!token) throw error(401, 'You must be logged in to use this API.')
 
 	const body = await request.text()

--- a/src/routes/api/get-generation/+server.ts
+++ b/src/routes/api/get-generation/+server.ts
@@ -11,7 +11,7 @@ export const POST: RequestHandler = async ({ cookies, fetch, request }) => {
 	const token =
 		import.meta.env.MODE === 'production'
 			? cookies.get(AUTH_COOKIE_NAME)
-			: import.meta.env.VITE_TOKEN
+			: import.meta.env.VITE_ZOO_DEV_TOKEN
 
 	const body = await request.json()
 

--- a/src/routes/api/submit-feedback/+server.ts
+++ b/src/routes/api/submit-feedback/+server.ts
@@ -8,7 +8,9 @@ export type LoadResponse = {
 }
 
 export const POST: RequestHandler = async ({ cookies, fetch, request }) => {
-	const token = import.meta.env.PROD ? cookies.get(AUTH_COOKIE_NAME) : import.meta.env.VITE_TOKEN
+	const token = import.meta.env.PROD
+		? cookies.get(AUTH_COOKIE_NAME)
+		: import.meta.env.VITE_ZOO_DEV_TOKEN
 	const body = await request.json()
 
 	if (!(body?.id && body?.feedback))

--- a/src/routes/api/submit-prompt/+server.ts
+++ b/src/routes/api/submit-prompt/+server.ts
@@ -9,7 +9,9 @@ export type PromptLoadResponse = {
 }
 
 export const POST: RequestHandler = async ({ cookies, fetch, request }) => {
-	const token = import.meta.env.PROD ? cookies.get(AUTH_COOKIE_NAME) : import.meta.env.VITE_TOKEN
+	const token = import.meta.env.PROD
+		? cookies.get(AUTH_COOKIE_NAME)
+		: import.meta.env.VITE_ZOO_DEV_TOKEN
 	if (!token) throw error(401, 'You must be logged in to use this API.')
 
 	const body = await request.json()


### PR DESCRIPTION
@alteous and I ran into some trouble making it slow to quickly get a dev environment up and running. These changes should make it much simpler to configure a local dev env, and make the instructions clearer, that a `VITE_ZOO_DEV_TOKEN` in `./.env` will be enough to successfully sign in in development mode.

It should also make the issue that I faced—a stale dev API token—much more clear to developers. Should they have a stale or otherwise broken API token in their env, they will not be redirected to the `/dashboard` page, their tests will fail, and a warning will appear in their console.