### PR TITLE
Delete the user's auth cookie if it's missing or invalid

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -29,7 +29,11 @@ export const handle = async ({ event, resolve }) => {
 		})
 		.then((res) => res.json())
 		.catch((e) => {
-			throw error(500, e)
+			// If the user had a token but there was an error fetching the user,
+			//delete the token, because it was likely revoked or expired
+			console.error('Error fetching user:', e)
+			event.cookies.delete(AUTH_COOKIE_NAME, { domain, path: '/' })
+			throw redirect(303, '/')
 		})
 
 	if (!currentUser) {


### PR DESCRIPTION
Users can get stuck with an invalid token in their cookies, and when this fetch of the user is called it would fail, but then I wouldn't delete the invalid cookie, leaving users continuously stuck. This will delete the cookie if the user fetch fails