### PR TITLE
Move responsibility of protecting routes out of hooks.server.ts

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,11 +1,8 @@
 import { redirect } from '@sveltejs/kit'
 import { AUTH_COOKIE_NAME } from '$lib/cookies'
 import { SIGN_OUT_PARAM } from '$lib/paths'
-import { PLAYWRIGHT_MOCKING_HEADER } from '$lib/consts'
+import { DOMAIN, PLAYWRIGHT_MOCKING_HEADER } from '$lib/consts'
 import { hooksUserMocks, isUserMock } from '$lib/mocks'
-const unProtectedRoutes = ['/', '/success']
-
-const domain = import.meta.env.DEV ? 'localhost' : '.zoo.dev'
 
 export const handle = async ({ event, resolve }) => {
 	const mock = event.request.headers.get(PLAYWRIGHT_MOCKING_HEADER)
@@ -13,9 +10,7 @@ export const handle = async ({ event, resolve }) => {
 		? event.cookies.get(AUTH_COOKIE_NAME)
 		: import.meta.env.VITE_TOKEN
 
-	if (!token && !unProtectedRoutes.includes(event.url.pathname)) {
-		throw redirect(303, '/')
-	} else if (!token) {
+	if (!token) {
 		return resolve(event)
 	}
 
@@ -32,18 +27,15 @@ export const handle = async ({ event, resolve }) => {
 			// If the user had a token but there was an error fetching the user,
 			//delete the token, because it was likely revoked or expired
 			console.error('Error fetching user:', e)
-			event.cookies.delete(AUTH_COOKIE_NAME, { domain, path: '/' })
-			throw redirect(303, '/')
+			signOut()
 		})
 
 	if (!currentUser) {
 		event.locals.user = undefined
-		if (!unProtectedRoutes.includes(event.url.pathname)) throw redirect(303, '/')
 	} else {
 		if ('error_code' in currentUser) {
 			console.error('Error fetching user:', currentUser.error_code)
-			event.cookies.delete(AUTH_COOKIE_NAME, { domain, path: '/' })
-			throw redirect(303, '/')
+			signOut()
 		}
 
 		event.locals.user = currentUser
@@ -56,9 +48,16 @@ export const handle = async ({ event, resolve }) => {
 	const query = event.url.searchParams.get(SIGN_OUT_PARAM)
 
 	if (Boolean(query) == true) {
-		event.cookies.delete(AUTH_COOKIE_NAME, { domain, path: '/' })
+		signOut()
+	}
+	return resolve(event)
+
+	/**
+	 * Shared sign out function
+	 */
+	function signOut() {
+		event.cookies.delete(AUTH_COOKIE_NAME, { domain: DOMAIN, path: '/' })
 		event.url.searchParams.delete(SIGN_OUT_PARAM)
 		throw redirect(303, '/')
 	}
-	return resolve(event)
 }

--- a/src/lib/consts.ts
+++ b/src/lib/consts.ts
@@ -3,6 +3,7 @@ import { msSinceStartOfDay, msSinceStartOfMonth, msSinceAWeekAgo, msSinceStartOf
 export const PERSIST_KEY_VERSION = '2024-06-21'
 export const PERSIST_KEY_GENERATIONS = 'TEXT_TO_CAD_GENERATIONS'
 export const PERSIST_KEY_UNREAD = 'TEXT_TO_CAD_UNREAD'
+export const DOMAIN = import.meta.env.DEV ? 'localhost' : '.zoo.dev'
 
 export const PLAYWRIGHT_MOCKING_HEADER = 'x-playwright-mocking'
 

--- a/src/routes/(sidebarLayout)/+layout.server.ts
+++ b/src/routes/(sidebarLayout)/+layout.server.ts
@@ -1,0 +1,11 @@
+import { DOMAIN } from '$lib/consts.js'
+import { AUTH_COOKIE_NAME } from '$lib/cookies.js'
+import { redirect } from '@sveltejs/kit'
+
+export const load = async ({ locals, cookies }) => {
+	// redirect user if not logged in
+	if (!locals.user) {
+		cookies.delete(AUTH_COOKIE_NAME, { domain: DOMAIN, path: '/' })
+		throw redirect(302, '/')
+	}
+}


### PR DESCRIPTION
Trying more work to repair #129. Now trying to remove the burden of protecting routes off of `hooks.server.ts`, and instead put it on the `+layout.server.ts` to redirect the user home and delete their cookie if they don't have a user there.