### PR TITLE
Revert "Try getting token from headers more directly, use locals for route blocking"

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -6,7 +6,6 @@ declare global {
 		// interface Error {}
 		interface Locals {
 			user?: Models['User_type'] | Models['Error_type']
-			token?: string
 		}
 		// interface PageData {}
 		// interface Platform {}

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -7,13 +7,11 @@ import { hooksUserMocks, isUserMock } from '$lib/mocks'
 export const handle = async ({ event, resolve }) => {
 	const mock = event.request.headers.get(PLAYWRIGHT_MOCKING_HEADER)
 	const token = import.meta.env.PROD
-		? event.request.headers.get(AUTH_COOKIE_NAME)
+		? event.cookies.get(AUTH_COOKIE_NAME)
 		: import.meta.env.VITE_TOKEN
 
 	if (!token) {
 		return resolve(event)
-	} else {
-		event.locals.token = token
 	}
 
 	const currentUser = await event

--- a/src/routes/(sidebarLayout)/+layout.server.ts
+++ b/src/routes/(sidebarLayout)/+layout.server.ts
@@ -5,7 +5,6 @@ import { redirect } from '@sveltejs/kit'
 export const load = async ({ locals, cookies }) => {
 	// redirect user if not logged in
 	if (!locals.user) {
-		locals.token = undefined
 		cookies.delete(AUTH_COOKIE_NAME, { domain: DOMAIN, path: '/' })
 		throw redirect(302, '/')
 	}

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,7 +1,14 @@
+import { AUTH_COOKIE_NAME } from '$lib/cookies.js'
+
 /** @type {import('./$types').LayoutData} */
-export const load = async ({ locals }) => {
+export const load = async ({ locals, cookies }) => {
+	const token =
+		import.meta.env.MODE === 'production'
+			? cookies.get(AUTH_COOKIE_NAME)
+			: import.meta.env.VITE_TOKEN
+
 	return {
 		user: !locals.user || 'error_code' in locals.user ? undefined : locals.user,
-		token: locals.token
+		token
 	}
 }

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,8 +1,10 @@
-import { paths } from '$lib/paths.js'
+import { AUTH_COOKIE_NAME } from '$lib/cookies.js'
 import { redirect } from '@sveltejs/kit'
 
-export const load = async ({ url, locals }) => {
-	if (locals.token && locals.user) {
-		throw redirect(302, paths.DASHBOARD + (url.search || ''))
+export const load = async ({ cookies, url }) => {
+	const token = import.meta.env.PROD ? cookies.get(AUTH_COOKIE_NAME) : import.meta.env.VITE_TOKEN
+
+	if (token) {
+		throw redirect(302, '/dashboard' + (url.search || ''))
 	}
 }


### PR DESCRIPTION
Reverts KittyCAD/text-to-cad-ui#144, that didn't work. I'm gonna leave it in a not-more-broken state and reach out on the Svelte Discord.