### PR TITLE
add max-height style to allow long prompt text to scroll and not escape viewport

### DIFF
--- a/src/components/PromptForm.svelte
+++ b/src/components/PromptForm.svelte
@@ -87,7 +87,7 @@
 			required
 			spellcheck="false"
 			disabled={isSubmitting}
-			class="w-full tracking-wide px-4 py-1 focus:outline-none focus:bg-green/20 focus:placeholder-shown:bg-green/10"
+			class="w-full tracking-wide px-4 py-1 focus:outline-none focus:bg-green/20 focus:placeholder-shown:bg-green/10 max-h-64"
 			bind:this={input}
 			bind:value={inputValue}
 			on:keydown={handleKeydown}


### PR DESCRIPTION
hi! cool product! was playing around and noticed some bugginess with the prompt text input field where if there's a long prompt the textarea will not scroll and it will keep expanding until it goes off the top edge of the viewport. i was able to run this locally to test (had to hack out some stuff to get the prompt textarea to render); see before & after screenshots. 

one other thing, fwiw: i didn't understand is why the `<textarea />` has `spellcheck="false"`? i'm the worst at spelling so not having red squiggles wouldn't be my preference. there's probably a reason for it, tho; so i didn't change it. 

also looking forward to the resolve from #138 because it was a little confusing at first that i couldn't edit the prompt again. it wasn't very difficult to realize i just needed to create a new prompt and copy/paste my old one in to keep editing. oh and deleting prompts would be cool, too. 🤷 


## before 

`Text-to-CAD` heading gets pushed off screen and so do the context of the prompt text; the text is not able to scroll.

<img width="1512" alt="before Screenshot 2024-08-20 at 11 17 48 AM" src="https://github.com/user-attachments/assets/fb831b09-7d75-4b6d-b9ee-4dfcca7975b1">

## after 

heading stays, text can scroll (see scrollbar 😎)
 
<img width="1512" alt="after Screenshot 2024-08-20 at 11 24 37 AM" src="https://github.com/user-attachments/assets/9844093d-0686-4e20-8bb6-c6adc2bef5db">
