### PR TITLE
Clear localStorage when user signs out

### DIFF
--- a/src/components/AccountMenu.svelte
+++ b/src/components/AccountMenu.svelte
@@ -96,7 +96,13 @@
 				<span class="flex-1 text-left">Report UI Issue</span>
 				<ArrowRight class="w-5 h-5 inline-block origin-center -rotate-45 ml-1" />
 			</a>
-			<a data-sveltekit-reload href={paths.SIGN_OUT} class="menu-button" on:keydown={dismiss}>
+			<a
+				data-sveltekit-reload
+				href={paths.SIGN_OUT}
+				class="menu-button"
+				on:keydown={dismiss}
+				on:click={() => localStorage.clear()}
+			>
 				<span class="flex-1 text-left">Sign Out</span>
 				<ArrowLeft class="w-5 h-5 inline-block origin-center -rotate-45 ml-1" />
 			</a>

--- a/src/routes/(sidebarLayout)/+layout.server.ts
+++ b/src/routes/(sidebarLayout)/+layout.server.ts
@@ -57,6 +57,7 @@ export const load = async ({ cookies, request, url, fetch }) => {
 	 */
 	function signOut() {
 		cookies.delete(AUTH_COOKIE_NAME, { domain: DOMAIN, path: '/' })
+		localStorage.clear()
 		throw redirect(303, '/')
 	}
 }

--- a/src/routes/(sidebarLayout)/+layout.server.ts
+++ b/src/routes/(sidebarLayout)/+layout.server.ts
@@ -57,7 +57,6 @@ export const load = async ({ cookies, request, url, fetch }) => {
 	 */
 	function signOut() {
 		cookies.delete(AUTH_COOKIE_NAME, { domain: DOMAIN, path: '/' })
-		localStorage.clear()
 		throw redirect(303, '/')
 	}
 }


### PR DESCRIPTION
In case users sign out from shared devices or otherwise, we don't want the next user to see their generations.