### PR TITLE
Add clairty script to head

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -45,6 +45,13 @@
 			property="og:image:secure_url"
 			content="https://text-to-cad.zoo.dev/zoo-text-to-cad-social.jpg"
 		/>
+    <script type="text/javascript">
+        (function(c,l,a,r,i,t,y){
+            c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+            t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+            y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+        })(window, document, "clarity", "script", "s0kr7hbbws");
+    </script>
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">


### PR DESCRIPTION
I believe this closes #178 by adding the Microsoft Clarity script to the head of the app. We want to see if users are getting confused using this interface, and if they're trying out their results in Zoo Design Studio, which is going to continue to be our primary app.