### PR TITLE
t2c generator instead of t2c ui

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -17,7 +17,7 @@
 	<section class="mx-auto max-w-5xl flex-1">
 		<div class="grid grid-cols-1 md:grid-cols-3 gap-0 items-stretch min-h-[33vh]">
 			<h1 class="md:col-span-2 text-5xl md:text-7xl py-6 md:py-12 self-center px-2 md:px-4">
-				Text-to-CAD <span class="text-green">UI</span>
+				Text-to-CAD <span class="text-green">Generator</span>
 			</h1>
 			<div class="z-10 relative border md:border-b-0 md:col-span-1 min-h-[25vh]">
 				<div


### PR DESCRIPTION
new:

<img width="1202" alt="Screenshot 2025-06-17 at 00 40 16" src="https://github.com/user-attachments/assets/fff7e6c3-4093-47ed-bf27-72db7b9df35c" />

old:
<img width="1168" alt="Screenshot 2025-06-17 at 00 40 47" src="https://github.com/user-attachments/assets/38eb40dc-3ed8-4ed6-beee-f8eba727406b" />
