### PR TITLE
Revert Zoo logo link to lead to dashboard, not website

### DIFF
--- a/src/components/Sidebar.svelte
+++ b/src/components/Sidebar.svelte
@@ -34,7 +34,7 @@
 			{/if}
 			<span class="sr-only">Open menu</span>
 		</button>
-		<a href={paths.ZOO_SITE} rel="noopener noreferrer" target="_blank">
+		<a href={paths.DASHBOARD}>
 			<Logo className="h-6 hover:text-green" />
 		</a>
 		<a


### PR DESCRIPTION
Text-to-CAD Generator is sometimes a funnel toward Zoo's website, but users can learn about Zoo and our APIs via links in the footer. Leave the Zoo logo in the top nav to do what they usually do, return to the "home page" of the app.