### PR TITLE
Add `ask-open-desktop` param to ZDS link

### DIFF
--- a/src/routes/(sidebarLayout)/view/[modelId]/+page.svelte
+++ b/src/routes/(sidebarLayout)/view/[modelId]/+page.svelte
@@ -30,7 +30,7 @@
 	$: gltfUrl = `data:model/gltf+json;base64,${data.outputs ? data.outputs['source.gltf'] : ''}`
 
 	$: zooDesignStudioUrl = data.code
-		? `https://app.zoo.dev?create-file=true&name=deeplinkscopy&code=${encodeURIComponent(
+		? `https://app.zoo.dev?ask-open-desktop=true&create-file=true&name=deeplinkscopy&code=${encodeURIComponent(
 				btoa(data.code)
 		  )}`
 		: ''


### PR DESCRIPTION
Since our implementation of temporary workspaces in browser Zoo Design Studio as of https://github.com/KittyCAD/modeling-app/pull/7393, we need to add this query parameter to links like this one so that it can pick up on the temporary workspace logic. We can upstream a fix to let the temporary workspace logic run without it from the ZDS side separately, but this is a no-harm fix in the meantime.

@lee-at-zoo-corp made a good point that we should really question if we need a query parameter for "ask to open in desktop" at all, especially if it's going to create logic slotting footguns like this.