### PR TITLE
Run CI hourly to detect dependency changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   pull_request:
+  schedule:
+    - cron: 0 * * * *
 
 permissions:
   contents: read
@@ -19,8 +21,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
-          cache: 'yarn'
+          node-version-file: .nvmrc
+          cache: yarn
 
       - run: yarn install
 
@@ -40,8 +42,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
-          cache: 'yarn'
+          node-version-file: .nvmrc
+          cache: yarn
 
       - run: yarn install
 
@@ -60,8 +62,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
-          cache: 'yarn'
+          node-version-file: .nvmrc
+          cache: yarn
 
       - run: yarn install
 


### PR DESCRIPTION
The Text-to-CAD Generator relies on lots of dependencies: Text-to-CAD, Zoo Design Studio (Web), Engine

We want to run the end-to-end tests on a schedule to detect breaking changes, especially in the query parameters "interface" that enables the onboarding funnel. This change actually runs the whole CI suite but it's still so fast this shouldn't really matter.