### PR TITLE
Switch to Namespace runners for CI reliability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   static-analysis:
     name: Static Analysis
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-ubuntu-2-cores
 
     steps:
       - uses: actions/checkout@v4
@@ -34,7 +34,7 @@ jobs:
 
   unit-tests:
     name: Unit Tests
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-ubuntu-2-cores
     timeout-minutes: 10
 
     steps:
@@ -53,7 +53,7 @@ jobs:
 
   e2e-tests:
     name: E2E Tests
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-ubuntu-2-cores
     timeout-minutes: 10
     environment: CI
 


### PR DESCRIPTION
The default GitHub runners also had 2 CPUs so this should be equivalent.