### PR TITLE
Pipe through the error message if there is one from the prompt form

### DIFF
--- a/src/components/PromptForm.svelte
+++ b/src/components/PromptForm.svelte
@@ -37,7 +37,12 @@
 		})
 
 		if (!response.ok) {
-			error = 'Failed to submit prompt'
+			const errorBody = await response.json()
+			if (errorBody && typeof errorBody === 'object' && 'message' in errorBody) {
+				error = errorBody.message
+			} else {
+				error = 'Failed to submit prompt'
+			}
 			return
 		}
 


### PR DESCRIPTION
Following some guidance from @iterion on our errors, which will always have a JSON-encoded body that contains a `message` string property if it's returned from our API. If we have that, we should use it, and only show "Failed to submit prompt" as a fallback.