### PR TITLE
chore(deps)!: upgrade @kittycad/lib to v3, v2 was a Morty

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "text2cad",
 			"version": "0.0.1",
 			"dependencies": {
-				"@kittycad/lib": "2.0.40",
+				"@kittycad/lib": "^3.0.0",
 				"@kittycad/react-shared": "^0.1.4",
 				"@threlte/core": "^6.1.0",
 				"@threlte/extras": "^7.3.0",
@@ -1067,17 +1067,23 @@
 			}
 		},
 		"node_modules/@kittycad/lib": {
-			"version": "2.0.40",
-			"resolved": "https://registry.npmjs.org/@kittycad/lib/-/lib-2.0.40.tgz",
-			"integrity": "sha512-vCTw2Dd8PnX3vHyoBfiGlxcwOY1BK8JAn4O8bWsNEeOlYoIB0JxQvR4m4OpSMwRVZ8EfHBQp3XxwibTrm38eCA==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@kittycad/lib/-/lib-3.0.0.tgz",
+			"integrity": "sha512-r4xq9R3KFVHFj1zsX+bSSPi1c/QwzZQlerSs5bCtfeF/nJSEppDYghAZ1Hquss9vAH5oVi50CwBerG+thz4Zjw==",
 			"license": "MIT",
 			"dependencies": {
+				"bson": "^6.8.0",
+				"cross-fetch": "^4.0.0",
 				"openapi-types": "^12.0.0",
 				"ts-node": "^10.9.1",
-				"tslib": "~2.8"
+				"tslib": "~2.8",
+				"ws": "^8.17.0"
 			},
 			"engines": {
 				"node": ">= 16.13"
+			},
+			"optionalDependencies": {
+				"win-ca": "^3.0.0"
 			}
 		},
 		"node_modules/@kittycad/react-shared": {
@@ -2863,6 +2869,15 @@
 				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
 			}
 		},
+		"node_modules/bson": {
+			"version": "6.10.4",
+			"resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
+			"integrity": "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=16.20.1"
+			}
+		},
 		"node_modules/buffer-crc32": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
@@ -3208,6 +3223,15 @@
 				"node": ">=10.14",
 				"npm": ">=6",
 				"yarn": ">=1"
+			}
+		},
+		"node_modules/cross-fetch": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
+			"integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
+			"license": "MIT",
+			"dependencies": {
+				"node-fetch": "^2.7.0"
 			}
 		},
 		"node_modules/cross-spawn": {
@@ -5111,6 +5135,13 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/is-electron": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
+			"integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==",
+			"license": "MIT",
+			"optional": true
+		},
 		"node_modules/is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -5715,6 +5746,29 @@
 				"@jridgewell/sourcemap-codec": "^1.5.0"
 			}
 		},
+		"node_modules/make-dir": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+			"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"pify": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/make-dir/node_modules/pify": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+			"integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/make-error": {
 			"version": "1.3.6",
 			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -6004,7 +6058,6 @@
 			"version": "2.7.0",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
 			"integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"whatwg-url": "^5.0.0"
@@ -6025,25 +6078,32 @@
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
 			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/node-fetch/node_modules/webidl-conversions": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
 			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-			"dev": true,
 			"license": "BSD-2-Clause"
 		},
 		"node_modules/node-fetch/node_modules/whatwg-url": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
 			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"tr46": "~0.0.3",
 				"webidl-conversions": "^3.0.0"
+			}
+		},
+		"node_modules/node-forge": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+			"integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+			"license": "(BSD-3-Clause OR GPL-2.0)",
+			"optional": true,
+			"engines": {
+				"node": ">= 6.13.0"
 			}
 		},
 		"node_modules/node-gyp-build": {
@@ -8050,6 +8110,19 @@
 			"integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
 			"license": "CC0-1.0"
 		},
+		"node_modules/split": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"through": "2"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/stackback": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -8722,6 +8795,13 @@
 			"resolved": "https://registry.npmjs.org/three/-/three-0.160.1.tgz",
 			"integrity": "sha512-Bgl2wPJypDOZ1stAxwfWAcJ0WQf7QzlptsxkjYiURPz+n5k4RBDLsq+6f9Y75TYxn6aHLcWz+JNmwTOXWrQTBQ==",
 			"license": "MIT"
+		},
+		"node_modules/through": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+			"license": "MIT",
+			"optional": true
 		},
 		"node_modules/tiny-case": {
 			"version": "1.0.3",
@@ -10051,6 +10131,20 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/win-ca": {
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/win-ca/-/win-ca-3.5.1.tgz",
+			"integrity": "sha512-RNy9gpBS6cxWHjfbqwBA7odaHyT+YQNhtdpJZwYCFoxB/Dq22oeOZ9YCXMwjhLytKpo7JJMnKdJ/ve7N12zzfQ==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"is-electron": "^2.2.0",
+				"make-dir": "^1.3.0",
+				"node-forge": "^1.2.1",
+				"split": "^1.0.1"
+			}
+		},
 		"node_modules/word-wrap": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -10173,7 +10267,6 @@
 			"version": "8.18.3",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
 			"integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"@kittycad/lib": "2.0.40",
+		"@kittycad/lib": "^3.0.0",
 		"@kittycad/react-shared": "^0.1.4",
 		"@threlte/core": "^6.1.0",
 		"@threlte/extras": "^7.3.0",

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,11 +1,11 @@
-import type { Models } from '@kittycad/lib'
+import type { User, ApiErrorBody } from '@kittycad/lib'
 // See https://kit.svelte.dev/docs/types#app
 // for information about these interfaces
 declare global {
 	namespace App {
 		// interface Error {}
 		interface Locals {
-			user?: Models['User_type'] | Models['Error_type']
+			user?: User | ApiErrorBody
 		}
 		// interface PageData {}
 		// interface Platform {}

--- a/src/components/AccountMenu.svelte
+++ b/src/components/AccountMenu.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-	import type { Models } from '@kittycad/lib/types'
+	import type { User } from '@kittycad/lib'
 	import { paths } from '$lib/paths'
 	import Person from './Icons/Person.svelte'
 	import CaretDown from './Icons/CaretDown.svelte'
 	import Link from './Icons/Link.svelte'
 
-	export let user: Models['User_type']
+	export let user: User
 	let open = false
 	let shouldDisplayImage = Boolean(user?.image && user.image !== '')
 	let shouldDisplayInitial =

--- a/src/components/AccountMenu.test.ts
+++ b/src/components/AccountMenu.test.ts
@@ -1,8 +1,8 @@
 import { render } from '@testing-library/svelte'
 import AccountMenu from './AccountMenu.svelte'
-import type { Models } from '@kittycad/lib/types'
+import type { User } from '@kittycad/lib'
 
-const FULL_USER: Models['User_type'] = {
+const FULL_USER: User = {
 	id: 'some_id',
 	name: 'Frank Noirot',
 	email: 'zoo_employee@zoo.dev',
@@ -21,19 +21,19 @@ const FULL_USER: Models['User_type'] = {
 	is_onboarded: true,
 	is_service_account: false
 }
-const NAME_USER: Models['User_type'] = {
+const NAME_USER: User = {
 	...FULL_USER,
 	image: ''
 }
-const FIRST_NAME_USER: Models['User_type'] = {
+const FIRST_NAME_USER: User = {
 	...NAME_USER,
 	name: ''
 }
-const EMAIL_USER: Models['User_type'] = {
+const EMAIL_USER: User = {
 	...FIRST_NAME_USER,
 	first_name: ''
 }
-const FAILED_USER: Models['User_type'] = {
+const FAILED_USER: User = {
 	...EMAIL_USER,
 	email: ''
 }
@@ -59,7 +59,7 @@ describe('AccountMenu', async () => {
 		expect(component.getByAltText('Avatar')).not.toBeVisible()
 		const initial = await component.getByTestId('initial')
 		expect(initial).toBeVisible()
-		expect(initial.textContent).toBe(NAME_USER.name[0])
+		expect(initial.textContent).toBe(NAME_USER.name![0])
 	})
 
 	it('fallback initial appears if first_name is available', async () => {
@@ -72,7 +72,7 @@ describe('AccountMenu', async () => {
 		expect(component.getByAltText('Avatar')).not.toBeVisible()
 		const initial = await component.getByTestId('initial')
 		expect(initial).toBeVisible()
-		expect(initial.textContent).toBe(FIRST_NAME_USER.first_name[0])
+		expect(initial.textContent).toBe(FIRST_NAME_USER.first_name![0])
 	})
 
 	it('fallback initial appears if email is available', async () => {
@@ -85,7 +85,7 @@ describe('AccountMenu', async () => {
 		expect(component.getByAltText('Avatar')).not.toBeVisible()
 		const initial = await component.getByTestId('initial')
 		expect(initial).toBeVisible()
-		expect(initial.textContent).toBe(FIRST_NAME_USER.email[0])
+		expect(initial.textContent).toBe(FIRST_NAME_USER.email![0])
 	})
 
 	it('user outline appears if all other options fail', async () => {

--- a/src/components/AppHeader.svelte
+++ b/src/components/AppHeader.svelte
@@ -1,5 +1,5 @@
 <script lang="ts" type="module">
-	import type { Models } from '@kittycad/lib/types'
+	import type { User } from '@kittycad/lib'
 	import AccountMenu from 'components/AccountMenu.svelte'
 	import { APP_NAME } from '$lib/consts'
 	import { paths } from '$lib/paths'
@@ -7,7 +7,7 @@
 	import Plus from 'components/Icons/Plus.svelte'
 	import { page } from '$app/stores'
 
-	export let user: Models['User_type']
+	export let user: User
 </script>
 
 <header id="app-header" data-testid="app-header">

--- a/src/components/BlockedMessage.svelte
+++ b/src/components/BlockedMessage.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import { paths } from '$lib/paths'
-	import type { Models } from '@kittycad/lib/types'
+	import type { BlockReason } from '@kittycad/lib'
 
-	export let blockedReason: Models['User_type']['block']
+	export let blockedReason: BlockReason
 </script>
 
 <div class="p-4 text-xl text-blue border border-blue bg-blue/10 rounded">

--- a/src/components/DownloadButton.svelte
+++ b/src/components/DownloadButton.svelte
@@ -8,7 +8,7 @@
 	import { tick } from 'svelte'
 
 	export let prompt: string = ''
-	export let outputs: PromptResponse['outputs']
+	export let outputs: Record<string, string>
 	export let className: string = ''
 	export let code: string = ''
 	let link: HTMLAnchorElement
@@ -62,8 +62,13 @@
 				return
 			}
 
-			outputs[`source.${currentOutput}`] = responseData.outputs[`source.${currentOutput}`]
-			outputData = outputs[`source.${currentOutput}`]
+			if (responseData.outputs && responseData.outputs[`source.${currentOutput}`]) {
+				outputs[`source.${currentOutput}`] = responseData.outputs[`source.${currentOutput}`]
+				outputData = outputs[`source.${currentOutput}`]
+			} else {
+				status = 'failed'
+				return
+			}
 		}
 		status = outputData ? 'ready' : 'failed'
 

--- a/src/components/GenerationList.svelte
+++ b/src/components/GenerationList.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { Models } from '@kittycad/lib/types'
+	import type { TextToCadResponse, TextToCadResponseResultsPage } from '@kittycad/lib'
 	import type { UIEventHandler } from 'svelte/elements'
 	import GenerationListItem from './GenerationListItem.svelte'
 	import { endpoints } from '$lib/endpoints'
@@ -49,7 +49,7 @@
 			return
 		}
 
-		const nextBatchPayload = (await response.json()) as Models['TextToCadResultsPage_type']
+		const nextBatchPayload = (await response.json()) as TextToCadResponseResultsPage
 
 		// If we see that one of fetched generations has an id that matches one of the
 		// generations in the store, we know we can stop fetching
@@ -72,7 +72,7 @@
 		}
 	}
 
-	function updateFetchedGenerations(payload: Models['TextToCadResultsPage_type']): boolean {
+	function updateFetchedGenerations(payload: TextToCadResponseResultsPage): boolean {
 		const nextBatch = payload?.items ?? []
 		let shouldKeepFetching = true
 		fetchedGenerations.update((g) => {
@@ -81,7 +81,7 @@
 			const newGenerations = [...nextBatch, ...g]
 			const newGenerationsDeduplicated = Array.from(
 				new Set(newGenerations.map((item) => item.id))
-			).map((id) => newGenerations.find((item) => item.id === id)) as Models['TextToCad_type'][]
+			).map((id) => newGenerations.find((item) => item.id === id)) as TextToCadResponse[]
 
 			shouldKeepFetching =
 				newGenerationsDeduplicated.length !== g.length &&

--- a/src/components/GenerationListItem.svelte
+++ b/src/components/GenerationListItem.svelte
@@ -13,7 +13,7 @@
 	} from '$lib/stores'
 	import ArrowRight from './Icons/ArrowRight.svelte'
 	import { MODEL_POLLING_INTERVAL } from '$lib/consts'
-	import type { Models } from '@kittycad/lib/types'
+	import type { TextToCadResponse } from '@kittycad/lib'
 
 	export let data: GenerationWithSource
 	let poller: ReturnType<typeof setInterval> | undefined
@@ -25,16 +25,9 @@
 	function updateGenerationItem(newItem: GenerationWithSource) {
 		const store = newItem.source === 'local' ? localGenerations : fetchedGenerations
 		store.update((g) => {
-			const itemNoModels: Models['TextToCad_type'] = {
-				...newItem,
-				outputs: {
-					'source.gltf': '',
-					'source.stl': ''
-				}
-			}
-			const foundIndex = g.findIndex((item) => item.id === itemNoModels.id)
+			const foundIndex = g.findIndex((item) => item.id === newItem.id)
 
-			return [...g.slice(0, foundIndex), itemNoModels, ...g.slice(foundIndex + 1)]
+			return [...g.slice(0, foundIndex), newItem, ...g.slice(foundIndex + 1)]
 		})
 	}
 
@@ -49,7 +42,7 @@
 		const res = await fetch(endpoints.viewNoModels(id), {
 			headers: { 'Content-Type': 'application/json', Authorization: 'Bearer ' + $page.data.token }
 		})
-		const newResponse: Models['TextToCad_type'] = await res.json().catch((err) => {
+		const newResponse: TextToCadResponse = await res.json().catch((err) => {
 			console.error(err)
 			error = { message: 'Failed to poll for generation status', status: res.status }
 		})
@@ -71,7 +64,7 @@
 	class={'generation-item group' +
 		($page.url.pathname.includes(data.id) ? ' current pointer-events-none' : '')}
 >
-	<span class="text">{data.prompt.trim()}</span>
+	<span class="text">{(data.prompt ?? '').trim()}</span>
 	<div class="group-hover:hidden group-focus:hidden">
 		{#if data.status === 'completed'}
 			<Checkmark

--- a/src/components/PromptForm.svelte
+++ b/src/components/PromptForm.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import autosize from 'svelte-autosize'
 	import { page } from '$app/stores'
-	import type { Models } from '@kittycad/lib/types'
+	import type { FileExportFormat, TextToCadResponse } from '@kittycad/lib'
 	import ArrowRight from './Icons/ArrowRight.svelte'
 	import { endpoints } from '$lib/endpoints'
 	import { localGenerations, unreadGenerations } from '$lib/stores'
@@ -26,7 +26,7 @@
 	}
 
 	const submitPrompt = async (prompt: string) => {
-		const OUTPUT_FORMAT: Models['FileExportFormat_type'] = 'gltf'
+		const OUTPUT_FORMAT: FileExportFormat = 'gltf'
 		const response = await fetch(endpoints.prompt(OUTPUT_FORMAT), {
 			method: 'POST',
 			headers: {
@@ -48,7 +48,7 @@
 
 		const responseData = (await response
 			.json()
-			.catch((e) => console.error('failed to parse response data', e))) as Models['TextToCad_type']
+			.catch((e) => console.error('failed to parse response data', e))) as TextToCadResponse
 
 		if (responseData) {
 			$localGenerations = [responseData, ...$localGenerations]

--- a/src/lib/endpoints.ts
+++ b/src/lib/endpoints.ts
@@ -1,8 +1,14 @@
-import type { Models } from '@kittycad/lib/types'
+import type {
+	FileExportFormat,
+	CreatedAtSortMode,
+	TextToCadResponseResultsPage,
+	MlFeedback,
+	TextToCad
+} from '@kittycad/lib'
 import { ITEMS_PER_PAGE } from './consts'
 import { env } from '$lib/env'
 
-export type CADFormat = Models['FileExportFormat_type']
+export type CADFormat = FileExportFormat
 
 export const CADMIMETypes = {
 	fbx: 'application/octet-stream', // FBX is not supported by MIME Type
@@ -17,13 +23,13 @@ export const CADMIMETypes = {
 interface ListParams {
 	limit?: number
 	page_token?: string
-	sort_by?: Models['CreatedAtSortMode_type']
+	sort_by?: CreatedAtSortMode
 }
 
 export const endpoints = {
 	convert: (output_format: CADFormat = 'obj') =>
 		`${env.VITE_API_BASE_URL}/file/conversion/gltf/${output_format}`,
-	feedback: (id: string, feedback: Models['TextToCad_type']['feedback']) =>
+	feedback: (id: string, feedback: MlFeedback) =>
 		`${env.VITE_API_BASE_URL}/user/text-to-cad/${id}?feedback=${feedback}`,
 	list: ({ limit = ITEMS_PER_PAGE, page_token }: ListParams) =>
 		`${env.VITE_API_BASE_URL}/user/text-to-cad?no_models=true&limit=${limit}${
@@ -37,6 +43,6 @@ export const endpoints = {
 	localFeedback: `/api/submit-feedback`
 }
 
-export type PromptResponse = Models['TextToCad_type']
+export type PromptResponse = TextToCad
 
-export type ListResponse = Models['TextToCadResultsPage_type']
+export type ListResponse = TextToCadResponseResultsPage

--- a/src/lib/mocks.ts
+++ b/src/lib/mocks.ts
@@ -1,4 +1,4 @@
-import type { Models } from '@kittycad/lib/types'
+import type { User } from '@kittycad/lib'
 
 const mockUserKeys = ['mockUserMissingPayment', 'mockUserFailedPayment'] as const
 export type MockUserMethod = (typeof mockUserKeys)[number]
@@ -7,17 +7,17 @@ type MockMethods<T extends string, M> = {
 	[K in T]: (input: M) => M
 }
 
-const mockUserMissingPayment = (user: Models['User_type']): Models['User_type'] => ({
+const mockUserMissingPayment = (user: User): User => ({
 	...user,
 	block: 'missing_payment_method'
 })
 
-const mockUserFailedPayment = (user: Models['User_type']): Models['User_type'] => ({
+const mockUserFailedPayment = (user: User): User => ({
 	...user,
 	block: 'payment_method_failed'
 })
 
-export const hooksUserMocks: MockMethods<MockUserMethod, Models['User_type']> = {
+export const hooksUserMocks: MockMethods<MockUserMethod, User> = {
 	mockUserMissingPayment,
 	mockUserFailedPayment
 }

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -1,4 +1,4 @@
-import type { Models } from '@kittycad/lib/types'
+import type { TextToCadResponse } from '@kittycad/lib'
 import { derived, writable, type Readable } from 'svelte/store'
 import groupBy from 'object.groupby'
 import { PERSIST_KEY_GENERATIONS, PERSIST_KEY_UNREAD, PERSIST_KEY_VERSION } from './consts'
@@ -13,7 +13,7 @@ if (browser && localStorage.getItem(PERSIST_KEY_VERSION) !== PERSIST_KEY_VERSION
 	localStorage.setItem(PERSIST_KEY_VERSION, PERSIST_KEY_VERSION)
 }
 
-export const localGenerations = writable<Models['TextToCad_type'][]>([])
+export const localGenerations = writable<TextToCadResponse[]>([])
 export const unreadGenerations = writable<string[]>(
 	browser ? JSON.parse(localStorage.getItem(PERSIST_KEY_UNREAD) ?? '[]') : []
 )
@@ -22,11 +22,11 @@ unreadGenerations.subscribe((value) => {
 		localStorage.setItem(PERSIST_KEY_UNREAD, JSON.stringify(value))
 	}
 })
-export const fetchedGenerations = writable<Models['TextToCad_type'][]>(
+export const fetchedGenerations = writable<TextToCadResponse[]>(
 	browser ? JSON.parse(localStorage.getItem(PERSIST_KEY_GENERATIONS) ?? '[]') : []
 )
 
-export type GenerationWithSource = Models['TextToCad_type'] & { source: 'local' | 'fetched' }
+export type GenerationWithSource = TextToCadResponse & { source: 'local' | 'fetched' }
 
 export const combinedGenerations = derived(
 	[localGenerations, fetchedGenerations],

--- a/src/routes/(sidebarLayout)/view/[modelId]/+page.svelte
+++ b/src/routes/(sidebarLayout)/view/[modelId]/+page.svelte
@@ -3,7 +3,7 @@
 	import ModelViewer from 'components/ModelViewer.svelte'
 	import ModelFeedback from 'components/ModelFeedback.svelte'
 	import DownloadButton from 'components/DownloadButton.svelte'
-	import type { Models } from '@kittycad/lib/types'
+	import type { TextToCad } from '@kittycad/lib'
 	import Spinner from 'components/Icons/Spinner.svelte'
 	import { browser } from '$app/environment'
 	import ErrorCard from 'components/ErrorCard.svelte'
@@ -12,7 +12,7 @@
 	import { navigating } from '$app/stores'
 	import Checkmark from 'components/Icons/Checkmark.svelte'
 
-	export let data: Models['TextToCad_type']
+	export let data: TextToCad
 	$: status = $combinedGenerations.find((g) => g.id === data.id)?.status ?? data.status
 	let isSceneEmpty = false
 

--- a/src/routes/(sidebarLayout)/view/[modelId]/+page.ts
+++ b/src/routes/(sidebarLayout)/view/[modelId]/+page.ts
@@ -1,5 +1,5 @@
 import { endpoints } from '$lib/endpoints.js'
-import type { Models } from '@kittycad/lib/types'
+import type { TextToCad } from '@kittycad/lib'
 import { error, redirect } from '@sveltejs/kit'
 
 /** @type {import('./$types').PageLoad} */
@@ -28,5 +28,5 @@ export async function load({ params, parent, fetch }) {
 		throw error(response.status, 'Failed to fetch model')
 	}
 
-	return (await response.json()) as Models['TextToCad_type']
+	return (await response.json()) as TextToCad
 }

--- a/src/routes/api/convert/[output_format]/+server.ts
+++ b/src/routes/api/convert/[output_format]/+server.ts
@@ -1,11 +1,11 @@
 import { CADMIMETypes, endpoints } from '$lib/endpoints'
 import { error, json } from '@sveltejs/kit'
 import type { RequestHandler } from './$types'
-import type { Models } from '@kittycad/lib/types'
+import type { FileConversion, FileExportFormat } from '@kittycad/lib'
 import { AUTH_COOKIE_NAME } from '$lib/cookies'
 import { env } from '$lib/env'
 
-export type ConvertResponse = Models['FileConversion_type'] & {
+export type ConvertResponse = FileConversion & {
 	statusCode: number
 }
 
@@ -21,19 +21,16 @@ export const POST: RequestHandler = async ({ cookies, fetch, request, params }) 
 		throw error(422, 'Invalid output format.')
 	}
 
-	const response = await fetch(
-		endpoints.convert(params.output_format as Models['FileExportFormat_type']),
-		{
-			method: 'POST',
-			headers: {
-				'Content-Type': 'application/octect-stream',
-				Authorization: `Bearer ${token}`
-			},
-			body
-		}
-	)
+	const response = await fetch(endpoints.convert(params.output_format as FileExportFormat), {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/octect-stream',
+			Authorization: `Bearer ${token}`
+		},
+		body
+	})
 
-	const data = (await response.json()) as Models['FileConversion_type']
+	const data = (await response.json()) as FileConversion
 
 	return json({
 		statusCode: response.status,


### PR DESCRIPTION
- Migrate to v3 API, replace Models map with named types (User, TextToCad, etc), update endpoints and tests, and use a proper isErr guard in billing
- Hardening: handle missing outputs in DownloadButton, safe prompt trim, drop the "no models" placeholder; lockfile updated with new deps

BREAKING CHANGE: @kittycad/lib v3 removes the Models type map, use named exports from @kittycad/lib instead and adjust related types accordingly