### PR TITLE
Fix error with `btoa()`

### DIFF
--- a/src/lib/base64.ts
+++ b/src/lib/base64.ts
@@ -1,0 +1,27 @@
+/**
+ * Converts a string to a base64 string, preserving the UTF-8 encoding
+ */
+export function stringToBase64(str: string) {
+	return bytesToBase64(new TextEncoder().encode(str))
+}
+
+/**
+ * Converts a base64 string to a string, preserving the UTF-8 encoding
+ */
+export function base64ToString(base64: string) {
+	return new TextDecoder().decode(base64ToBytes(base64))
+}
+
+/**
+ * From the MDN Web Docs
+ * https://developer.mozilla.org/en-US/docs/Glossary/Base64#the_unicode_problem
+ */
+function base64ToBytes(base64: string) {
+	const binString = atob(base64)
+	return Uint8Array.from(binString, (m) => m.codePointAt(0)!)
+}
+
+function bytesToBase64(bytes: Uint8Array) {
+	const binString = Array.from(bytes, (byte) => String.fromCodePoint(byte)).join('')
+	return btoa(binString)
+}

--- a/src/routes/(sidebarLayout)/view/[modelId]/+page.svelte
+++ b/src/routes/(sidebarLayout)/view/[modelId]/+page.svelte
@@ -10,6 +10,7 @@
 	import { combinedGenerations, unreadGenerations, userSettings } from '$lib/stores'
 	import { invalidateAll, onNavigate } from '$app/navigation'
 	import { navigating } from '$app/stores'
+	import { stringToBase64 } from '$lib/base64'
 	import Checkmark from 'components/Icons/Checkmark.svelte'
 
 	export let data: TextToCad
@@ -31,7 +32,7 @@
 
 	$: zooDesignStudioUrl = data.code
 		? `https://app.zoo.dev?ask-open-desktop=true&create-file=true&name=deeplinkscopy&code=${encodeURIComponent(
-				btoa(data.code)
+				stringToBase64(data.code)
 		  )}`
 		: ''
 </script>


### PR DESCRIPTION
There is an issue with rendering pages for prompts whose code contains non Latin1 characters. This should fix that.

<img width="2986" height="1436" alt="Screenshot 2025-09-29 at 11 39 05 AM" src="https://github.com/user-attachments/assets/e2d5b989-fd09-482d-84a6-f5e167b33e7f" />
